### PR TITLE
Update open_graph_tags_lite.php

### DIFF
--- a/open_graph_tags_lite/helpers/open_graph_tags_lite.php
+++ b/open_graph_tags_lite/helpers/open_graph_tags_lite.php
@@ -54,8 +54,12 @@ class OpenGraphTagsLiteHelper {
 		$og_image = $page->getAttribute('og_image');
 		if (!$og_image instanceof File) {
 			$og_image = $page->getAttribute('page_thumbnail');
-			if (!$og_image instanceof File && !empty($thumbnailID)) {
-				$og_image = File::getByID($thumbnailID);
+			if (!$og_image instanceof File) {
+				// Additional tests added by JtF to extend sources to a blog thumbnail attribute
+				$og_image = $page->getAttribute('blog_thumbnail'); 
+				if (!$og_image instanceof File && !empty($thumbnailID)) {
+					$og_image = File::getByID($thumbnailID);
+				}
 			}
 		}
 		


### PR DESCRIPTION
Additional tests added to extend sources to a blog thumbnail attribute.

Blogs often use a 'blog_thumbnail' attribute. So I extended the image source attribute test in my copy. I suppose a better pull would be to make the name of the source attribute configurable, but that would be a fair bit more work.