### PR TITLE
on_start fires in AJAX, results in error in Sitemap

### DIFF
--- a/open_graph_tags_lite/controller.php
+++ b/open_graph_tags_lite/controller.php
@@ -49,7 +49,7 @@ class Controller extends \Concrete\Core\Package\Package {
     public function on_start()
     {
         $ogp = new OpenGraphTags();
-        Events::addListener('on_start', array($ogp,'insertTags'));
+        Events::addListener('on_before_render', array($ogp,'insertTags'));
     }
 
 }


### PR DESCRIPTION
The on_start event fires in every request including AJAX. It may break the responses via AJAX, used in Dashboard Sitemap.
The on_start event is too early to output html tags.
I propose on_before_render instead of on_start.
http://concrete5-japan.org/community/forums/beginner/post-12756/